### PR TITLE
fix: check for undefined properties

### DIFF
--- a/frontend/src/components/burps/burp_box.jsx
+++ b/frontend/src/components/burps/burp_box.jsx
@@ -4,6 +4,11 @@ import avatars from '../../images/avatars';
 import { Link } from 'react-router-dom';
 
 const BurpBox = (props) => {
+  
+  if (!props.owner) {
+    return null
+  }
+  
   // debugger
   return (
     <div className="burpbox">

--- a/frontend/src/components/burps/burps.jsx
+++ b/frontend/src/components/burps/burps.jsx
@@ -29,8 +29,8 @@ class Burp extends React.Component {
                   text={burp.text}
                   burp={burp}
                   owner = {user}
-                  avatar={user.avatar}
-                  author={user.handle}
+                  avatar={user?.avatar || ''}
+                  author={user?.handle || ''}
                 />
               );
             });


### PR DESCRIPTION
Came across this project and thought the UI design is very nice. 

But it crashed on me during login.. 

So figured I'd make some contributions.

These props seem to be undefined when loading the app for the first time upon login:

### `avatar`
![image](https://user-images.githubusercontent.com/20848851/107117082-868a6a80-682c-11eb-8ea2-015db5866c1c.png)

### `_id`
![image](https://user-images.githubusercontent.com/20848851/107117097-a6219300-682c-11eb-93f8-dd48db5ca06c.png)
